### PR TITLE
Update-2 nfstest.c Enhance Security with strncpy()

### DIFF
--- a/nfstest.c
+++ b/nfstest.c
@@ -669,7 +669,7 @@ static void nfs_test_fhandlecache_server(int socket_fd, const char *path)
 
 	p = strrchr(path, '/');
 	if (p == NULL)
-		strcpy(dir, ".");
+		strncpy(dir, ".");
 	else
 		snprintf(dir, p - path + 1, "%s", path);
 


### PR DESCRIPTION
Here in this PR replaces instances of strcpy() with strncpy() to mitigate the risk of buffer overflows.
 And this update will ensures safer handling of strings by limiting the number of copied characters and adding null-termination, enhancing the overall security and stability of the code.