### PR TITLE
added a check if maildirlock_path exists and a meaningful error message

### DIFF
--- a/maildir-size-fix.pl
+++ b/maildir-size-fix.pl
@@ -12,6 +12,8 @@ use File::Basename;
 use strict;
 
 my $maildirlock_path = "/usr/local/libexec/dovecot/maildirlock";
+# Check if the maildirlock_path exists.
+-e $maildirlock_path or die "maildirlock file /usr/local/libexec/dovecot/maildirlock does not seem to exist, consider checking its location and edit this script if required";
 
 # If UIDLs are based on filename and no P<uidl> entry already exist for
 # a message, write a P<original filename> entry so it doesn't change when


### PR DESCRIPTION
Hi, how are you?
I ran into a misleading error message about the $pid variable today on a system that had the maildirlock at /usr/lib/dovecot/maildirlock, and thought it might be worth to add a check if the maildirlock_path exists, and die with a meaningful error if not.